### PR TITLE
Add config for testing using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+rvm:
+- 2.2
+sudo: required
+dist: trusty
+cache:
+  directories:
+  - "$HOME/.berkshelf"
+addons:
+  apt:
+    sources:
+    - chef-stable-precise
+    packages:
+    - chefdk
+install:
+- eval "$(chef shell-init bash)"
+before_script:
+- berks
+- chef --version
+- rubocop --version
+- foodcritic --version
+script:
+- rubocop
+- foodcritic .

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -23,8 +23,8 @@ case node[:zookeeper][:service_style]
 when 'upstart'
   template '/etc/default/zookeeper' do
     source 'environment-defaults.erb'
-    owner 'zookeeper'
-    group 'zookeeper'
+    owner node[:zookeeper][:user]
+    group node[:zookeeper][:user]
     action :create
     mode '0644'
     notifies :restart, 'service[zookeeper]', :delayed
@@ -58,8 +58,8 @@ when 'runit'
 when 'sysv'
   template '/etc/default/zookeeper' do
     source 'environment-defaults.erb'
-    owner 'zookeeper'
-    group 'zookeeper'
+    owner node[:zookeeper][:user]
+    group node[:zookeeper][:user]
     action :create
     mode '0644'
     notifies :restart, 'service[zookeeper]', :delayed


### PR DESCRIPTION
@jakedavis, might be nice to get Travis CI set up to do some basic testing. This is also capable of doing integration testing, using `kitchen-ec2` or another cloud platform Kitchen driver.

Also, this will require someone that has admin rights to this repo to add it to Travis CI.

Partially fixes #85 