### PR TITLE
Fix environment

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -40,6 +40,6 @@ end
 # Add optional Zookeeper environment vars
 file "#{node['zookeeper']['config_dir']}" % { zookeeper_version: node['zookeeper']['version'] } + '/zookeeper-env.sh' do
   owner node['zookeeper']['user']
-  content exports_config(node['zookeeper']['env_vars'])
+  content lazy { exports_config(node['zookeeper']['env_vars']) }
   only_if { node['zookeeper']['env_vars'] }
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -38,7 +38,7 @@ zookeeper node['zookeeper']['version'] do
 end
 
 # Add optional Zookeeper environment vars
-file "#{node['zookeeper']['config_dir']}/zookeeper-env.sh" do
+file "#{node['zookeeper']['config_dir']}" % { zookeeper_version: node['zookeeper']['version'] } + '/zookeeper-env.sh' do
   owner node['zookeeper']['user']
   content exports_config(node['zookeeper']['env_vars'])
   only_if { node['zookeeper']['env_vars'] }

--- a/templates/default/environment-defaults.erb
+++ b/templates/default/environment-defaults.erb
@@ -21,3 +21,7 @@ if [ -z "$JMXDISABLE" ]; then
       -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port="<%= node['zookeeper']['jmx_local'] %>" \
       -Dcom.sun.management.jmxremote.local.only=$JMXLOCALONLY"
 fi
+
+
+export ZOO_LOG_DIR=${ZOO_LOG_DIR}
+export ZOO_LOG4J_PROP=${ZOO_LOG4J_PROP}


### PR DESCRIPTION
This PR solved three issues for me: 

1. zookeeper-env.sh was could not be written as path was faulty (contained `%{zookeeper_version}`)
2. `exports_config` was evaluated with value "true"
3. with sysv style startup `/etc/default/zookeeper` was executed but now passed to subshells as variables were not exported. Exported some variables.