### PR TITLE
fix for link error in ark

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -62,6 +62,10 @@ action :install do
     system      true
   end
 
+  directory install_dir do
+    recursive true
+  end
+ 
   ark 'zookeeper' do
     url         "#{mirror}/zookeeper-#{new_resource.version}/zookeeper-#{new_resource.version}.tar.gz"
     version     new_resource.version

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -69,10 +69,6 @@ action :install do
     prefix_home install_dir
     checksum    new_resource.checksum if property_is_set? :checksum
   end
-  
-  #directory install_dir do
-  #  recursive true
-  #end
 
   directory log_dir do
     owner     username

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -62,9 +62,17 @@ action :install do
     system      true
   end
 
-  directory install_dir do
-    recursive true
+  ark 'zookeeper' do
+    url         "#{mirror}/zookeeper-#{new_resource.version}/zookeeper-#{new_resource.version}.tar.gz"
+    version     new_resource.version
+    prefix_root install_dir
+    prefix_home install_dir
+    checksum    new_resource.checksum if property_is_set? :checksum
   end
+  
+  #directory install_dir do
+  #  recursive true
+  #end
 
   directory log_dir do
     owner     username
@@ -78,14 +86,6 @@ action :install do
     group     username
     mode      '0700'
     recursive true
-  end
-
-  ark 'zookeeper' do
-    url         "#{mirror}/zookeeper-#{new_resource.version}/zookeeper-#{new_resource.version}.tar.gz"
-    version     new_resource.version
-    prefix_root install_dir
-    prefix_home install_dir
-    checksum    new_resource.checksum if property_is_set? :checksum
   end
 end
 


### PR DESCRIPTION
This is a fix that I have tested and works to fix #183. I simply moved up the ark resource to be performed before the directories are created as ark will will link the the unpacked zookeeper archive with version number folder to the install_dir/zookeeper folder. The link step breaks though if the directory is created first before the link due to recursive directory declarations.