### PR TITLE
Change user to username in sysv script

### DIFF
--- a/templates/default/zookeeper.sysv.erb
+++ b/templates/default/zookeeper.sysv.erb
@@ -5,7 +5,7 @@
 # chkconfig: 2345 90 10
 # description: zookeeper
 
-USER="<%= @user %>"
+USER="<%= @username %>"
 CMD="<%= @exec %>"
 BIN_DIR="$(dirname "${CMD}")"
 CURRENT_USER="$(/usr/bin/whoami)"


### PR DESCRIPTION
It looks like user was changed to username in a lot of places recently, but the change was omitted from the sysv script.