### PR TITLE
Fix Permissions

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -32,8 +32,8 @@ property :java_opts
 
 action :render do
   file "#{conf_dir}/#{conf_file}" do
-    owner   user
-    group   user
+    owner   new_resource.user
+    group   new_resource.user
     content properties_config(config)
   end
 
@@ -46,7 +46,8 @@ action :render do
   env_vars_hash['JVMFLAGS']    = java_opts if java_opts
 
   file "#{conf_dir}/zookeeper-env.sh" do
-    owner   user
+    owner   new_resource.user
+    group   new_resource.user
     content exports_config(env_vars_hash) + "\n"
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -72,6 +72,8 @@ action :install do
     prefix_root install_dir
     prefix_home install_dir
     checksum    new_resource.checksum if new_resource.checksum
+    owner       username
+    group       username
   end
 
   directory log_dir do


### PR DESCRIPTION
All files and directories in /opt/zookeeper are being installed as root. This updates them to use the zookeeper user.

Files being owned by root is causing the following issue in https://github.com/evertrue/exhibitor-cookbook

```
2017-02-08_11:07:50.94238 java.io.FileNotFoundException: /opt/zookeeper-3.4.9/conf/zoo.cfg (Permission denied)
2017-02-08_11:07:50.94238       at java.io.FileOutputStream.open(Native Method)
2017-02-08_11:07:50.94239       at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
2017-02-08_11:07:50.94239       at java.io.FileOutputStream.<init>(FileOutputStream.java:171)
2017-02-08_11:07:50.94240       at com.netflix.exhibitor.core.processes.StandardProcessOperations.prepConfigFile(StandardProcessOperations.java:167)
2017-02-08_11:07:50.94240       at com.netflix.exhibitor.core.processes.StandardProcessOperations.startInstance(StandardProcessOperations.java:109)
2017-02-08_11:07:50.94240       at com.netflix.exhibitor.core.state.KillRunningInstance.completed(KillRunningInstance.java:41)
2017-02-08_11:07:50.94240       at com.netflix.exhibitor.core.activity.ActivityQueue$1.run(ActivityQueue.java:127)
2017-02-08_11:07:50.94240       at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
2017-02-08_11:07:50.94240       at java.util.concurrent.FutureTask.run(FutureTask.java:262)
2017-02-08_11:07:50.94240       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
2017-02-08_11:07:50.94241       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
2017-02-08_11:07:50.94241       at java.lang.Thread.run(Thread.java:745)
```