### PR TITLE
give option to forgo service['zookeeper'] restart on service configuration update

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -34,7 +34,6 @@ property :restart_on_reconfig, default: true
 
 action :create do
   executable_path = "#{install_dir}/bin/zkServer.sh"
-  notify_action = restart_on_reconfig ? :restart : :nothing
 
   case service_style
   when 'runit'
@@ -61,7 +60,7 @@ action :create do
         username: username
       )
       cookbook template_cookbook
-      notifies notify_action, 'service[zookeeper]'
+      notifies :restart, 'service[zookeeper]' if restart_on_reconfig
     end
 
     service 'zookeeper' do
@@ -78,7 +77,7 @@ action :create do
         username: username
       )
       cookbook template_cookbook
-      notifies notify_action, 'service[zookeeper]'
+      notifies :restart, 'service[zookeeper]' if restart_on_reconfig
     end
 
     service_provider = value_for_platform_family(
@@ -106,7 +105,7 @@ action :create do
     execute 'systemctl daemon-reload' do
       action :nothing
       command '/bin/systemctl daemon-reload'
-      notifies notify_action, 'service[zookeeper]'
+      notifies :restart, 'service[zookeeper]' if restart_on_reconfig
     end
 
     service 'zookeeper' do

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -66,7 +66,7 @@ action :create do
 
     service 'zookeeper' do
       provider Chef::Provider::Service::Upstart
-      supports status: true, restart: true
+      supports status: true, restart: true, nothing: true
       action   service_actions
     end
   when 'sysv'
@@ -88,7 +88,7 @@ action :create do
 
     service 'zookeeper' do
       provider service_provider
-      supports status: true, restart: true
+      supports status: true, restart: true, nothing: true
       action   service_actions
     end
   when 'systemd'
@@ -111,7 +111,7 @@ action :create do
 
     service 'zookeeper' do
       provider Chef::Provider::Service::Systemd
-      supports status: true, restart: true
+      supports status: true, restart: true, nothing: true
       action   service_actions
     end
 


### PR DESCRIPTION
reason being, that even if you pass `[:stop, :disable]` to service_actions, if the service_config updates, it will restart zookeeper regardless, resulting in a running zookeeper.  Also there may be situations where you would not like to have zookeeper restart automatically. (controlled/rolling restarts, etc)