### PR TITLE
Use class variable to avoid creating new connection for each resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,11 @@ Style/SpaceBeforeFirstArg:
 Style/Documentation:
   Enabled: false
 
+# Offense count: 1
+Style/ClassVars:
+  Exclude:
+    - 'libraries/default.rb'
+
 # The default 79 character limit is sometimes unproductive.
 Metrics/LineLength:
   Max: 120

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -43,8 +43,8 @@ module Zk
   module Gem
     def zk
       require 'zookeeper'
-
-      @zk ||= ::Zookeeper.new(connect_str).tap do |zk|
+      # use class variable otherwise new connection is created for each resource
+      @@zk ||= ::Zookeeper.new(connect_str).tap do |zk|
         zk.add_auth scheme: auth_scheme, cert: auth_cert unless auth_cert.nil?
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'EverTrue'
 maintainer_email 'devops@evertrue.com'
 license          'Apache v2.0'
 description      'Installs/Configures zookeeper'
-version          '8.2.0'
+version          '8.2.1'
 
 issues_url 'https://github.com/evertrue/zookeeper-cookbook/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/evertrue/zookeeper-cookbook/' if respond_to?(:source_url)


### PR DESCRIPTION
In existing implementation, the zookeeper connection is cached in the class instance variable as part of the ZK::Gem module method, which is later mixed-in to the **zookeeper_node**  custom resource class. 
As a consequence, new ZK connection is created for each instance of the zookeeper node resource. As zookeeper has 60 connections allowed from single IP by default to protect from the DOS-attack, it means that total number of zookeeper node resources in a single run is also limited to 60 due to creation of new connection per each resource.
As a possible quick fix, I propose to use the class variable, allowing to share a connection object between all resource objects. 