### PR TITLE
Duplicate immutable property to support chef 13

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -39,7 +39,7 @@ action :render do
 
   # Ensure that, even if an attribute is passed in, we can
   # operate on it without running into read-only issues
-  env_vars_hash = env_vars.to_hash
+  env_vars_hash = env_vars.to_hash.dup
   env_vars_hash['ZOOCFGDIR']   = conf_dir
   env_vars_hash['ZOOCFG']      = conf_file
   env_vars_hash['ZOO_LOG_DIR'] = log_dir


### PR DESCRIPTION
In Chef Client 13 some types of resource properties became immutable, including Hash.
So, in order to change the "environment" hash, we need to create a mutable copy first.

cc: @evertrue @jeffbyrnes