### PR TITLE
Remove EOL Ubuntu 1404

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  chef_version: 14
+  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   privileged: true # because Docker and SystemD/Upstart
 
 transport:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,7 +22,7 @@ platforms:
       pid_one_command: /bin/systemd
     attributes:
       java:
-        jdk_version: '7'
+        jdk_version: '8'
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
@@ -37,7 +37,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
     attributes:
       java:
-        jdk_version: '7'
+        jdk_version: '8'
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,7 @@ transport:
 
 provisioner:
   name: dokken
-  deprecations_as_errors: true
+  deprecations_as_errors: false
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  chef_version: latest
+  chef_version: 14
   privileged: true # because Docker and SystemD/Upstart
 
 transport:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,13 +16,6 @@ verifier:
   chef_license: accept
 
 platforms:
-  - name: ubuntu-14.04
-    driver:
-      image: dokken/ubuntu-14.04
-      pid_one_command: /sbin/init
-    attributes:
-      java:
-        jdk_version: '7'
   - name: ubuntu-16.04
     driver:
       image: dokken/ubuntu-16.04
@@ -63,16 +56,6 @@ suites:
   - name: systemd
     run_list:
       - recipe[zookeeper_tester::systemd]
-    includes:
-      - ubuntu-16.04
-      - ubuntu-18.04
-      - centos-7
     attributes:
       zookeeper:
         conf_dir: /etc/zookeeper/conf
-
-  - name: upstart
-    run_list:
-      - recipe[zookeeper_tester::upstart]
-    includes:
-      - ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,9 @@ if: (type = pull_request) OR (tag IS present) OR (branch = master)
 cache:
   directories:
   - "$HOME/.berkshelf"
-addons:
-  apt:
-    sources:
-    - chef-stable-xenial
-    packages:
-    - chefdk
 services: docker
 install:
+- curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chefdk -v 3
 - eval "$(chef shell-init bash)"
 before_script:
 - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: trusty
+dist: xenial
 sudo: false
 if: (type = pull_request) OR (tag IS present) OR (branch = master)
 cache:
@@ -8,7 +8,7 @@ cache:
 addons:
   apt:
     sources:
-    - chef-stable-trusty
+    - chef-stable-xenial
     packages:
     - chefdk
 services: docker
@@ -24,15 +24,12 @@ env:
   - CHEF_LICENSE='accept'
   matrix:
   - TEST='delivery local verify'
-  - TEST='kitchen test default-ubuntu-1404'
   - TEST='kitchen test default-ubuntu-1604'
   - TEST='kitchen test default-ubuntu-1804'
   - TEST='kitchen test default-centos-7'
-  - TEST='kitchen test attributes-ubuntu-1404'
   - TEST='kitchen test attributes-ubuntu-1604'
   - TEST='kitchen test attributes-ubuntu-1804'
   - TEST='kitchen test attributes-centos-7'
-  - TEST='kitchen test upstart-ubuntu-1404'
   - TEST='kitchen test systemd-ubuntu-1604'
   - TEST='kitchen test systemd-ubuntu-1804'
   - TEST='kitchen test systemd-centos-7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,34 @@
+---
 language: ruby
 dist: xenial
 sudo: false
 if: (type = pull_request) OR (tag IS present) OR (branch = master)
 cache:
   directories:
-  - "$HOME/.berkshelf"
+    - "$HOME/.berkshelf"
 services: docker
 install:
-- curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chefdk -v 3
-- eval "$(chef shell-init bash)"
+  - curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chefdk -v 3
+  - eval "$(chef shell-init bash)"
 before_script:
-- sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables
-  -N DOCKER )
-- chef --version
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables
+    -N DOCKER )
+  - chef --version
 script: $TEST
 env:
   global:
-  - CHEF_LICENSE='accept'
+    - CHEF_LICENSE='accept'
   matrix:
-  - TEST='delivery local verify'
-  - TEST='kitchen test default-ubuntu-1604'
-  - TEST='kitchen test default-ubuntu-1804'
-  - TEST='kitchen test default-centos-7'
-  - TEST='kitchen test attributes-ubuntu-1604'
-  - TEST='kitchen test attributes-ubuntu-1804'
-  - TEST='kitchen test attributes-centos-7'
-  - TEST='kitchen test systemd-ubuntu-1604'
-  - TEST='kitchen test systemd-ubuntu-1804'
-  - TEST='kitchen test systemd-centos-7'
+    - TEST='delivery local verify'
+    - TEST='kitchen test default-ubuntu-1604'
+    - TEST='kitchen test default-ubuntu-1804'
+    - TEST='kitchen test default-centos-7'
+    - TEST='kitchen test attributes-ubuntu-1604'
+    - TEST='kitchen test attributes-ubuntu-1804'
+    - TEST='kitchen test attributes-centos-7'
+    - TEST='kitchen test systemd-ubuntu-1604'
+    - TEST='kitchen test systemd-ubuntu-1804'
+    - TEST='kitchen test systemd-centos-7'
 notifications:
   slack:
     secure: Bh2Lb596AhPXzFOviP+pVhQaZxXN1ry3swomyXELNvKRbQPcdHNn4slgZXhWplRo1XQUsSGSBmrdwoNAWpvNGQnLTyz8hAI1wmUnc0KEF/4RGaKbzsuuhvctFbiSaO1u/Y9yZ1hT9RW6fbM4TepJ5+DoI0q9PxDRuXPnGd2RnWg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,101 @@ before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables
     -N DOCKER )
   - chef --version
-script: $TEST
 env:
   global:
     - CHEF_LICENSE='accept'
-  matrix:
-    - TEST='delivery local verify'
-    - TEST='kitchen test default-ubuntu-1604'
-    - TEST='kitchen test default-ubuntu-1804'
-    - TEST='kitchen test default-centos-7'
-    - TEST='kitchen test attributes-ubuntu-1604'
-    - TEST='kitchen test attributes-ubuntu-1804'
-    - TEST='kitchen test attributes-centos-7'
-    - TEST='kitchen test systemd-ubuntu-1604'
-    - TEST='kitchen test systemd-ubuntu-1804'
-    - TEST='kitchen test systemd-centos-7'
+jobs:
+  include:
+    - stage: Verify
+      script: delivery local verify
+      env:
+        - CHEF_VERSION=14
+    - stage: Verify
+      script: delivery local verify
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: default-ubuntu-1604'
+      script: kitchen test default-ubuntu-1604
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: default-ubuntu-1604'
+      script: kitchen test default-ubuntu-1604
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: default-ubuntu-1804'
+      script: kitchen test default-ubuntu-1804
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: default-ubuntu-1804'
+      script: kitchen test default-ubuntu-1804
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: default-centos-7'
+      script: kitchen test default-centos-7
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: default-centos-7'
+      script: kitchen test default-centos-7
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: attributes-ubuntu-1604'
+      script: kitchen test attributes-ubuntu-1604
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: attributes-ubuntu-1604'
+      script: kitchen test attributes-ubuntu-1604
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: attributes-ubuntu-1804'
+      script: kitchen test attributes-ubuntu-1804
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: attributes-ubuntu-1804'
+      script: kitchen test attributes-ubuntu-1804
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: attributes-centos-7'
+      script: kitchen test attributes-centos-7
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: attributes-centos-7'
+      script: kitchen test attributes-centos-7
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: systemd-ubuntu-1604'
+      script: kitchen test systemd-ubuntu-1604
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: systemd-ubuntu-1604'
+      script: kitchen test systemd-ubuntu-1604
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: systemd-ubuntu-1804'
+      script: kitchen test systemd-ubuntu-1804
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: systemd-ubuntu-1804'
+      script: kitchen test systemd-ubuntu-1804
+      env:
+        - CHEF_VERSION=15
+
+    - stage: 'Acceptance: systemd-centos-7'
+      script: kitchen test systemd-centos-7
+      env:
+        - CHEF_VERSION=14
+    - stage: 'Acceptance: systemd-centos-7'
+      script: kitchen test systemd-centos-7
+      env:
+        - CHEF_VERSION=15
+
 notifications:
   slack:
     secure: Bh2Lb596AhPXzFOviP+pVhQaZxXN1ry3swomyXELNvKRbQPcdHNn4slgZXhWplRo1XQUsSGSBmrdwoNAWpvNGQnLTyz8hAI1wmUnc0KEF/4RGaKbzsuuhvctFbiSaO1u/Y9yZ1hT9RW6fbM4TepJ5+DoI0q9PxDRuXPnGd2RnWg=

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version          '11.1.0'
 issues_url 'https://github.com/evertrue/zookeeper-cookbook/issues'
 source_url 'https://github.com/evertrue/zookeeper-cookbook/'
 
-supports         'ubuntu', '>= 14.04'
+supports         'ubuntu', '>= 16.04'
 supports         'centos', '~> 7.0'
 supports         'oracle', '~> 7.0'
 supports         'redhat', '~> 7.0'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -51,24 +51,6 @@ action :create do
       cookbook       new_resource.template_cookbook
       action         new_resource.service_actions
     end
-  when 'upstart'
-    template '/etc/init/zookeeper.conf' do
-      source 'zookeeper.upstart.erb'
-      mode   '0644'
-      variables(
-        zk_env: env_path,
-        exec: executable_path,
-        username: new_resource.username
-      )
-      cookbook new_resource.template_cookbook
-      notifies :restart, 'service[zookeeper]' if new_resource.restart_on_reconfig
-    end
-
-    service 'zookeeper' do
-      provider Chef::Provider::Service::Upstart
-      supports status: true, restart: true, nothing: true
-      action   new_resource.service_actions
-    end
   when 'systemd'
     template '/etc/systemd/system/zookeeper.service' do
       source 'zookeeper.systemd.erb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,3 @@ RSpec.configure do |config|
   config.color     = true
   config.formatter = :documentation
 end
-
-at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -19,16 +19,6 @@
 require 'spec_helper'
 
 describe 'zookeeper::default' do
-  context 'When all attributes are default, on Ubuntu 14.04' do
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04').converge described_recipe
-    end
-
-    it 'converges successfully' do
-      chef_run # This should not raise an error
-    end
-  end
-
   context 'When all attributes are default, on Ubuntu 16.04' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge described_recipe

--- a/test/cookbooks/zookeeper_tester/recipes/attributes.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/attributes.rb
@@ -1,4 +1,3 @@
-
 include_recipe 'zookeeper'
 include_recipe 'zookeeper::service'
 include_recipe 'zookeeper_tester::node'

--- a/test/cookbooks/zookeeper_tester/recipes/default.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/default.rb
@@ -1,4 +1,3 @@
-
 zookeeper node['zookeeper']['version'] do
   checksum node['zookeeper']['checksum']
 end

--- a/test/cookbooks/zookeeper_tester/recipes/systemd.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/systemd.rb
@@ -1,4 +1,3 @@
-
 zookeeper node['zookeeper']['version']
 zookeeper_config 'zoo.cfg'
 zookeeper_service 'zookeeper' do

--- a/test/cookbooks/zookeeper_tester/recipes/upstart.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/upstart.rb
@@ -1,7 +1,0 @@
-zookeeper node['zookeeper']['version']
-zookeeper_config 'zoo.cfg'
-zookeeper_service 'zookeeper' do
-  service_style 'upstart'
-end
-
-include_recipe 'zookeeper_tester::node'

--- a/test/cookbooks/zookeeper_tester/recipes/upstart.rb
+++ b/test/cookbooks/zookeeper_tester/recipes/upstart.rb
@@ -1,4 +1,3 @@
-
 zookeeper node['zookeeper']['version']
 zookeeper_config 'zoo.cfg'
 zookeeper_service 'zookeeper' do


### PR DESCRIPTION
Expands on @hrak’s work in.

Closes #220 

Original description of the work:

>This PR does the following:
> 
> * Remove support for EOL Ubuntu 14.04
> * Default to JDK version 8, because version 7 is EOL and support has been removed from recent versions of the java cookbook
> * Test with Chef client 14
> * Disable deprecations_as_errors to allow cookbook to converge on Chef 14
> * CHEF-25 is triggered due to inclusion of 'build-essential' cookbook, required for Chef clients < 14
> * Test on Ubuntu 16.04