### PR TITLE
Duplicate acl_<scheme> before update

### DIFF
--- a/resources/node.rb
+++ b/resources/node.rb
@@ -42,6 +42,8 @@ load_current_value do
     when 'world'
       acl_world acl[:perms]
     else
+      # default value for acl_digest is frozen by default in chef 14+
+      send("acl_#{acl[:id][:scheme]}=", send("acl_#{acl[:id][:scheme]}").dup)
       send("acl_#{acl[:id][:scheme]}")[acl[:id][:id]] = acl[:perms]
     end
   end


### PR DESCRIPTION
This is necessary in chef 14 since default values are frozen

Change-Id: I352a3449abb0135b65529dc68f5211213b60b7e6