### PR TITLE
Remove mentions of runit and upstart from zookeeper_service resource in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,7 @@ Actions: `:create`
 
 Properties:
 
-* `service_style`: The type of service provider you wish to use. Defaults to `runit`, and only allows one of the following:
-    - `runit`
-    - `upstart`
+* `service_style`: The type of service provider you wish to use. Defaults to `systemd`, and only allows one of the following:
     - `systemd`
     - `exhibitor`
 * `install_dir`: Where you’ve installed ZooKeeper (defaults to `/opt/zookeeper`)


### PR DESCRIPTION
Small PR to remove mentions of runit and upstart from zookeeper_service resource docs