### PR TITLE
Update java cookbook dependency to >=8.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ supports         'oracle', '>= 7.0'
 supports         'redhat', '>= 7.0'
 
 chef_version     '>= 15.0'
-depends          'java', '~> 8.2'
+depends          'java', '>= 8.2'
 depends          'magic', '>= 1.1'
 depends          'ark', '~> 5.0'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -53,8 +53,17 @@ action :install do
     recursive true
   end
 
+  versionRegExp = /(\d+)\.(\d+)(\.\d+)?/
+
+  match = new_resource.version.match(versionRegExp)
+  if match.captures[0].to_i == 3 && match.captures[1].to_i < 5
+    url = "#{new_resource.mirror}/zookeeper-#{new_resource.version}/zookeeper-#{new_resource.version}.tar.gz"
+  else
+    url = "#{new_resource.mirror}/zookeeper-#{new_resource.version}/apache-zookeeper-#{new_resource.version}-bin.tar.gz"
+  end
+  
   ark 'zookeeper' do
-    url         "#{new_resource.mirror}/zookeeper-#{new_resource.version}/apache-zookeeper-#{new_resource.version}-bin.tar.gz"
+    url         url
     version     new_resource.version
     prefix_root new_resource.install_dir
     prefix_home new_resource.install_dir


### PR DESCRIPTION
The java cookbook is clearly outdated since v11.1 has been released.

The kitchen test works the same with java cookbook in 8.2 and 11.1