### PR TITLE
Update java cookbook dependency to >=8.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ supports         'oracle', '>= 7.0'
 supports         'redhat', '>= 7.0'
 
 chef_version     '>= 15.0'
-depends          'java', '~> 8.2'
+depends          'java', '>= 8.2'
 depends          'magic', '>= 1.1'
 depends          'ark', '~> 5.0'


### PR DESCRIPTION
The java cookbook is clearly outdated since v11.1 has been released.